### PR TITLE
new flag --with-turbo-streams will append callbacks after_update_c…

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ For Importmap apps:
 ```
 ./bin/importmap pin "bootstrap@5.1.3" &&
 ./bin/importmap pin "@popperjs/core@2.11.2" &&
-echo "\nimport "bootstrap"\n" >> app/javascript/application.js &&
 git add . && git commit -m "pinning boostrap and popper js for bootstrap"
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ git add . && git commit -m "bootstrap install" &&
 bundle add font_awesome5_rails && 
 echo "\n@import 'font_awesome5_webfont';\n" >> app/assets/stylesheets/application.scss
 git add . && git commit -m "adds fontawesome" &&  
+bundle add kaminari && 
+rails generate kaminari:views bootstrap4 && 
+git add . && git commit -m "adding kaminari and views" &&
 bundle add devise && bundle install && 
 git add . && git commit -m "adding devise gem" && 
 rails generate devise:install && 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ git add . && git commit -m "schema file"
 
 For Importmap apps:
 ```
-pin "bootstrap", to: "https://ga.jspm.io/npm:bootstrap@5.1.3/dist/js/bootstrap.esm.js" &&
-pin "@popperjs/core", to: "https://ga.jspm.io/npm:@popperjs/core@2.11.2/lib/index.js" &&
+./bin/importmap pin "bootstrap@5.1.3" &&
+./bin/importmap pin "@popperjs/core@2.11.2" &&
 echo "\nimport "bootstrap"\n" >> app/javascript/application.js &&
 git add . && git commit -m "pinning boostrap and popper js for bootstrap"
 ```

--- a/dummy/Gemfile.lock
+++ b/dummy/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    hot-glue (0.5.2)
+    hot-glue (0.5.3)
       ffaker (~> 2.16)
       kaminari (~> 1.2)
       rails (> 5.1)

--- a/dummy/app/models/abc.rb
+++ b/dummy/app/models/abc.rb
@@ -1,4 +1,11 @@
 class Abc < ApplicationRecord
+  after_update_commit lambda { broadcast_replace_to self, target: "__#{dom_id(self)}", partial: "/abcs/line" }
+  after_destroy_commit lambda { broadcast_remove_to self, target: "__#{dom_id(self)}"}
+
+  include ActionView::RecordIdentifier
+  after_update_commit lambda { broadcast_replace_to self, target: "__#{dom_id(self)}", partial: "/abcs/line" }
+  after_destroy_commit lambda { broadcast_remove_to self, target: "__#{dom_id(self)}"}
+
 
   @@table_label_plural = "Apples"
   @@table_label_singular = "Apple"

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -415,6 +415,8 @@ module HotGlue
       @layout_object = builder.construct
 
       @menu_file_exists = true if @nested_set.none? && File.exists?("#{Rails.root}/app/views/#{namespace_with_trailing_dash}_menu.#{@markup}")
+
+      @turbo_streams = !!options['with_turbo_streams']
     end
 
     def setup_hawk_keys
@@ -943,7 +945,7 @@ module HotGlue
       # somehow the generator invokes this
       if options['with_turbo_streams'] == true
         dest_filename = cc_filename_with_extensions("#{singular_class.underscore}", "rb")
-        dest_filepath = File.join("app/models", dest_filename)
+        dest_filepath = File.join("#{'dummy/' if Rails.env.test?}app/models", dest_filename)
 
 
         puts "appending turbo callbacks to #{dest_filepath}"

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -122,7 +122,8 @@ module HotGlue
     class_option :smart_layout, type: :boolean, default: false
     class_option :markup, type: :string, default: nil # deprecated -- use in app config instead
     class_option :layout, type: :string, default: nil # if used here it will override what is in the config
-    class_option :hawk, type: :string, default: nil #
+    class_option :hawk, type: :string, default: nil
+    class_option :turbo_model_callbacks, type: :boolean, default: false
 
     class_option :no_list_label, type: :boolean, default: false
 
@@ -414,8 +415,6 @@ module HotGlue
       @layout_object = builder.construct
 
       @menu_file_exists = true if @nested_set.none? && File.exists?("#{Rails.root}/app/views/#{namespace_with_trailing_dash}_menu.#{@markup}")
-
-
     end
 
     def setup_hawk_keys
@@ -938,6 +937,28 @@ module HotGlue
       #
       # end
 
+    end
+
+    def append_model_callbacks
+      # somehow the generator invokes this
+      if options['turbo_model_callbacks'] == true
+        dest_filename = cc_filename_with_extensions("#{singular_class.underscore}", "rb")
+        dest_filepath = File.join("app/models", dest_filename)
+
+
+        puts "appending turbo callbacks to #{dest_filepath}"
+
+        text = File.read(dest_filepath)
+
+        append_text = "class #{singular_class} < ApplicationRecord\n"
+        if !text.include?("include ActionView::RecordIdentifier")
+          append_text << "  include ActionView::RecordIdentifier\n"
+        end
+        append_text << "  after_update_commit lambda { broadcast_replace_to self, target: \"#{@namespace}__\#{dom_id(self)}\", partial: \"#{@namespace}/#{@plural}/line\" }\n  after_destroy_commit lambda { broadcast_remove_to self, target: \"#{@namespace}__\#{dom_id(self)}\"}\n"
+
+        replace = text.gsub(/class #{singular_class} < ApplicationRecord/, append_text)
+        File.open(dest_filepath, "w") {|file| file.puts replace}
+      end
     end
 
     def namespace_with_dash

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -123,7 +123,7 @@ module HotGlue
     class_option :markup, type: :string, default: nil # deprecated -- use in app config instead
     class_option :layout, type: :string, default: nil # if used here it will override what is in the config
     class_option :hawk, type: :string, default: nil
-    class_option :turbo_model_callbacks, type: :boolean, default: false
+    class_option :with_turbo_streams, type: :boolean, default: false
 
     class_option :no_list_label, type: :boolean, default: false
 
@@ -941,7 +941,7 @@ module HotGlue
 
     def append_model_callbacks
       # somehow the generator invokes this
-      if options['turbo_model_callbacks'] == true
+      if options['with_turbo_streams'] == true
         dest_filename = cc_filename_with_extensions("#{singular_class.underscore}", "rb")
         dest_filepath = File.join("app/models", dest_filename)
 

--- a/lib/generators/hot_glue/templates/erb/_line.erb
+++ b/lib/generators/hot_glue/templates/erb/_line.erb
@@ -1,5 +1,5 @@
-<\%= turbo_stream_from <%= singular %>  %>
-<\%= turbo_frame_tag "<%= @namespace %>__#{ dom_id(<%= singular %>) }" do  %>
+<% if @turbo_streams %><\%= turbo_stream_from <%= singular %>  %>
+<% end %><\%= turbo_frame_tag "<%= @namespace %>__#{ dom_id(<%= singular %>) }" do  %>
   <div class='row scaffold-row' data-id='<\%= <%= singular  %>.id %>' data-edit='false'>
     <\%= render partial: '<%=  show_path_partial %>', locals: { <%= singular %>: <%= singular %> }<% @nested_set.each do |nest_arg| %>.merge(defined?(<%= nest_arg[:singular] %>) ? {<%= nest_arg[:singular] %>: <%= nest_arg[:singular] %>, nested_for: "<%= nest_arg[:singular] %>-#{<%= nest_arg[:singular] %>.id}"} : {})<% end %> %>
 

--- a/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
+++ b/spec/lib/generators/hot_glue/scaffold_generator_spec.rb
@@ -978,6 +978,22 @@ describe HotGlue::ScaffoldGenerator do
     end
   end
 
+  describe "--with-turbo-streamd" do
+    it "should not include turbo_stream_from if not specified" do
+      response = Rails::Generators.invoke("hot_glue:scaffold",
+                                         ["Abc", "--gd"])
+      res = File.read("spec/dummy/app/views/abcs/_line.erb")
+      expect(res).to_not include("<%= turbo_stream_from abc  %>")
+    end
+
+    it "should not include turbo_stream_from if not specified" do
+      response = Rails::Generators.invoke("hot_glue:scaffold",
+                                          ["Abc", "--gd", "--with-turbo-streams"])
+      res = File.read("spec/dummy/app/views/abcs/_line.erb")
+      expect(res).to include("<%= turbo_stream_from abc  %>")
+    end
+  end
+
   # describe "for when a base controller already exists" do
   #   it "should skip adding the base controller" do
   #     response = Rails::Generators.invoke("hot_glue:scaffold",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,6 @@ end
 # require rails first
 require "rails/all"
 
-# FileUtils.rm_rf("spec/dummy/spec/")
 
 require 'rails/generators'
 


### PR DESCRIPTION
…ommit and after_destroy_commit to the MODEL you are building with to use turbo to target the scaffolding being built and programmatically update it

Hot Glue now supports cross-client updating using Turbo Streams. That means if you have two browser windows open, make a change in one window, your change gets broadcast to the other window automatically. 

To turn it on, use `--with-turbo-streams`. If and only if you specify `--with-turbo-streams`, your views will contain `turbo_stream_from` directives. Whereas your views will always contain `turbo_frame_tags` (wether or not this flag is specified) and will use the Turbo stream replacement mechanism for non-idempotent actions (create & update). This flag just brings the magic of live-reload to the scaffold interfaces themselves.

 **_To test_**: Open the same interface in two separate browser windows. Make an edit in one window and watch your edit appear in the other window instantly. 

This happens using two interconnected mechanisms: 

1) by default, all Hot Glue scaffold is wrapped in `turbo_frame_tag`s. The id of these tags is your namespace + the Rails dom_id(...). That means all Hot Glue scaffold is namespaced to the namespaces you use and won't collide with other turbo_frame_tag you might be using elsewhere

2) by appending **model callbacks**, we can automatically broadcast updates to the users who are using the Hot Glue scaffold. The model callbacks (after_update_commit and after_destroy_commit) get appended automatically to the top of your model file. Each model callback targets the scaffold being built (so just this scaffold), using its namespace, and renders the line partial (or destroys the content in the case of delete) from the scaffolding.

please note that *creating* and *deleting* do not yet have a full & complete implementation: Your pages won't re-render the pages being viewed cross-peer (that is, between two users using the app at the same time) if the insertion or deletion causes the pagination to be off for another user. 

For example, if another user's view of the page would need to be repaginated, the interface won't automatically repaginate. (I have an experimental implementation but remain unhappy with the outcome). It also opens a can of worms in terms of not supporting things like special search or sorting, so I am leaving those off those two implementation details. For now, 'edit' does work correctly, destroy works by magic because it just removes the thing from the DOM (but can leave your views incorrectly paginated as discussed), and add only works because it re-renders the whole list without care for the pagination (which in fact only works correctly on unpaginated views). 

Honestly, I'm not really sure I love the Turbo pattern _for this use case_ so I am leaving these two details left unfinished.

If you want support to a 'meta' view in your turbo view for live reloading, here's what I recommend. For example, showing a list of records sorted newest-to-oldest, and new ones get appended to the top whenever they are added by someone other user.

I recommend all the records belong to a _parent record_ that gets touched whenever the children get updated, added, or destroyed. Then use a `turbo_stream_from` on the _parent record_ and wrap all of its contents, including child contents (presumably, a list of related child records), in a `turbo_stream_tag` corresponding to that parent record.

Then attach an emitter onto the parent model like so. In this example, we are emitting off a **things** model (the parent record) something in the namespace scope of "agent_dashboard" using a partial which happens to be at `agent/dashboard/things`. To this partial we pass a local variable called `thing`, which we pass the self of the Thing object that this got emitted from. In this arbitrary example, the child records are **Widgets**, and a thing `has_many :widgets`

```
class Thing < ApplicationRecord
  include ActionView::RecordIdentifier
  has_many :widgets
  broadcast_replace_to self, target: "agent_dashboard__#{dom_id(self)}",
                                                   partial: "agent/dashboard/things",
                                                   locals: {thing: self}}
   ...
end

class Widget < ApplicationRecord
   belongs_to :thing, touch: true
end

```

Now, anytime you created, edit, or delete a **Widget**, your entire dashboard page for the associated **Thing** gets re-rendered.