### PR TITLE
Jfb/2022 12 27 hawk removing scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,10 +573,10 @@ you can hawk the `pet_id` to the current human's pets. (Whoever is the authentic
 
 The hawk has two forms: a short-form (`--hawk=key`) and long form (`--hawk=key{scope})
 
-The short form looks like this:
+The short form looks like this. It presumes there is a 'pets' association from `current_user`
 `--hawk=pet_id`
 
-(The long form equavlent of this would be `--hawk=pet_id{current_user.pets}`)
+(The long form equivalent of this would be `--hawk=pet_id{current_user.pets}`)
 
 This is covered in [Example #3 in the Hot Glue Tutorial](https://jfb.teachable.com/courses/hot-glue-in-depth-tutorial/lectures/38584014)
 
@@ -585,7 +585,8 @@ to specify the scope. Be sure to note to add the association name itself, like `
 
 `--hawk=user_id{current_user.family.users}`
 
-This would hawk the Appointment's `user_id` key to any users who are within the scope of the current_user's `family.users` association (so, for any other member of my family). 
+This would hawk the Appointment's `user_id` key to any users who are within the scope of the 
+current_user's has_many association (so, for any other "my" family, would be `current_user.family.users`). 
 
 This is covered in [Example #4 in the Hot Glue Tutorial](https://jfb.teachable.com/courses/hot-glue-in-depth-tutorial/lectures/38787505)
 

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -437,7 +437,6 @@ module HotGlue
             hawk_entry =~ /(.*){(.*)}/
             key, hawk_to = $1, $2
           else
-            @use_shorthand = true
             key = hawk_entry
             hawk_to = @auth
           end

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -225,7 +225,7 @@ module HotGlue
         @singular = @singular.split("/").last
       end
 
-      @plural = options['plural'] || @singular.pluralize
+      @plural = options['plural'] || @singular.pluralize # respects what you set in inflections.rb, to override, use plural option
       @namespace = options['namespace'] || nil
 
 
@@ -437,7 +437,6 @@ module HotGlue
             hawk_entry =~ /(.*){(.*)}/
             key, hawk_to = $1, $2
           else
-            @use_shorthand = true
             key = hawk_entry
             hawk_to = @auth
           end

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -437,6 +437,7 @@ module HotGlue
             hawk_entry =~ /(.*){(.*)}/
             key, hawk_to = $1, $2
           else
+            @use_shorthand = true
             key = hawk_entry
             hawk_to = @auth
           end


### PR DESCRIPTION
--hawk=
Hawk a foreign key that is not the object's owner to within a specified scope.

Assuming a Pet belong_to a :human, when building an Appointments scaffold, you can hawk the pet_id to the current human's pets. (Whoever is the authentication object.)

The hawk has two forms: a short-form (--hawk=key) and long form (`--hawk=key{scope})

The short form looks like this. It presumes there is a 'pets' association from current_user --hawk=pet_id

(The long form equivalent of this would be --hawk=pet_id{current_user.pets})

This is covered in [Example #3 in the Hot Glue Tutorial](https://jfb.teachable.com/courses/hot-glue-in-depth-tutorial/lectures/38584014)

To hawk to a scope that is not the currently authenticated user, use the long form with {...} to specify the scope. Be sure to note to add the association name itself, like users:

--hawk=user_id{current_user.family.users}

This would hawk the Appointment's user_id key to any users who are within the scope of the current_user's has_many association (so, for any other "my" family, would be current_user.family.users).

This is covered in [Example #4 in the Hot Glue Tutorial](https://jfb.teachable.com/courses/hot-glue-in-depth-tutorial/lectures/38787505)