### PR TITLE
fixes spec assertions for enum to work with _label field; fixes form-…

### DIFF
--- a/lib/generators/hot_glue/markup_templates/erb.rb
+++ b/lib/generators/hot_glue/markup_templates/erb.rb
@@ -223,12 +223,13 @@ module  HotGlue
     end
 
     def boolean_result(col)
-      " <br />"  +
+      (form_labels_position == 'before' ?  " <br />"  : "") +
         "  <%= f.radio_button(:#{col},  '0', checked: #{singular}.#{col}  ? '' : 'checked') %>\n" +
         "  <%= f.label(:#{col}, value: 'No', for: '#{singular}_#{col}_0') %>\n" +
         "  <%= f.radio_button(:#{col}, '1',  checked: #{singular}.#{col}  ? 'checked' : '') %>\n" +
         "  <%= f.label(:#{col}, value: 'Yes', for: '#{singular}_#{col}_1') %>\n" +
-        ""
+      (form_labels_position == 'after' ?  " <br />"  : "")
+
     end
 
     def enum_result(col)

--- a/lib/generators/hot_glue/scaffold_generator.rb
+++ b/lib/generators/hot_glue/scaffold_generator.rb
@@ -641,7 +641,7 @@ module HotGlue
       end
 
       unless @no_specs
-        dest_file = File.join("#{'spec/dummy/' if Rails.env.test?}spec/system#{namespace_with_dash}", "#{plural}_behavior_spec.rb")
+        dest_file = File.join("#{'spec/dummy/' if Rails.env.test?}spec/features#{namespace_with_dash}", "#{plural}_behavior_spec.rb")
 
         if  File.exist?(dest_file)
           existing_file = File.open(dest_file)

--- a/lib/generators/hot_glue/templates/system_spec.rb.erb
+++ b/lib/generators/hot_glue/templates/system_spec.rb.erb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'interaction for <%= controller_class_name %>', type: :feature do
+describe 'interaction for <%= controller_class_name %>' do
   include HotGlue::ControllerHelper
   include ActionView::RecordIdentifier
 
@@ -72,9 +72,13 @@ describe 'interaction for <%= controller_class_name %>', type: :feature do
   when :uuid
     assoc_name = col.to_s.gsub('_id','')
     association = eval("#{singular_class}.reflect_on_association(:#{assoc_name})")
-
-
     "      " + ["expect(page).to have_content(#{singular}#{1}.#{assoc_name}.#{HotGlue.derrive_reference_name(association.class_name)})"].join("\n      ")
+  when :enum
+    if(eval("#{singular_class}.respond_to?(:#{col}_labels)"))
+     "      " + "expect(page).to have_content(#{singular_class}.#{col}_labels[#{singular}#{1}.#{col}])"
+    else
+     "      " + "expect(page).to have_content(new_#{col})"
+    end
 
   when :boolean
     "      " + ["expect(page).to have_content(#{singular}#{1}.#{col} ? 'YES' : 'NO')"].join("\n      ")
@@ -115,7 +119,12 @@ describe 'interaction for <%= controller_class_name %>', type: :feature do
 
     when :boolean
         ["expect(page).to have_content(#{singular}#{1}.#{col} ? 'YES' : 'NO')"].join("\n      ")
-
+    when :enum
+      if(eval("#{singular_class}.respond_to?(:#{col}_labels)"))
+        "expect(page).to have_content(#{singular_class}.#{col}_labels[new_#{col}])"
+      else
+        "expect(page).to have_content(new_#{col})"
+      end
     else
       "expect(page).to have_content(new_#{col})"
     end
@@ -146,9 +155,10 @@ describe 'interaction for <%= controller_class_name %>', type: :feature do
       elsif type == :boolean
       '        expect(page).to have_content(new_' + col.to_s + ' ? "YES" : "NO")'
 
+      elsif type == :enum && eval("#{singular_class}.respond_to?(:#{col}_labels)")
+       "        expect(page).to have_content(#{singular_class}.#{col}_labels[new_#{col}])"
       else
       '        expect(page).to have_content(new_' + col.to_s + ')'
-
       end
     }.compact.join("\n")
     %>


### PR DESCRIPTION
…label-position (before/after) to put a carriage return correctly between the label & field; all spec files are now created in spec/features/ folder (previously was system/)